### PR TITLE
[UPD] Build web container based on latest nightly code

### DIFF
--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -53,11 +53,9 @@ RUN set -x; \
 
 # Install Odoo
 ENV ODOO_VERSION 13.0
-ARG ODOO_RELEASE=20200121
-ARG ODOO_SHA=770d71cfafb9a8f8419b88f8033b964d5742ad57
+ARG ODOO_RELEASE=latest
 RUN set -x; \
         curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-        && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
         && dpkg --force-depends -i odoo.deb \
         && apt-get update \
         && apt-get -y install -f --no-install-recommends \

--- a/13.0/docker-compose.yml
+++ b/13.0/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  web:
+    build:
+      context: ./
+    depends_on:
+      - db
+    ports:
+      - "8069:8069"
+  db:
+    image: postgres:12
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=odoo
+      - POSTGRES_PASSWORD=odoo


### PR DESCRIPTION
The [Odoo-maintained docker repository](https://github.com/odoo/docker/) is maintaining the Odoo 13 image based on relatively older core code (~6 weeks old as of writing), which is older than Blue Stingray may want to be working with either locally or on customer instances.

Instead, the Blue Stingray-maintained docker repository will be based on the latest nightly Odoo 13 core code.

